### PR TITLE
DEVEM-534-ci-publish [Update] ci build to publish artifacts seperately.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/heads/master') }}
         run: mvn clean install
       #build and publish
-      - name: Publish alfresco-value-assistance packages
+      - name: Publish alfresco-value-assistance repo
         if: ${{ startsWith(github.ref, 'refs/heads/master') }}
         run: mvn --batch-mode deploy
+        working-directory: alfresco-value-assistance-repo
+      - name: Publish alfresco-value-assistance share
+        if: ${{ startsWith(github.ref, 'refs/heads/master') }}
+        run: mvn --batch-mode deploy
+        working-directory: alfresco-value-assistance-share


### PR DESCRIPTION
ticket: https://xenitsupport.jira.com/browse/BNPPFSLA-849
Updating the ci build to publish without failing.
